### PR TITLE
Fix env variable exposure

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,8 @@
 [DATA BASE CONNECTION]
 
-NEXT_PUBLIC_SERVER_URL=
-NEXT_PUBLIC_DB_NAME=
-NEXT_PUBLIC_DB_USER=
-NEXT_PUBLIC_DB_PASSWORD=
+# Connection details used only on the server. Do not prefix them with
+# NEXT_PUBLIC_ to avoid exposing them to the client.
+SERVER_URL=
+DB_NAME=
+DB_USER=
+DB_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Environment configuration
+
+Before running the application you must provide a `.env` file with the database
+connection details. Use `.env.template` as a starting point:
+
+```bash
+cp .env.template .env
+```
+
+Fill in the values for `SERVER_URL`, `DB_NAME`, `DB_USER` and `DB_PASSWORD`.
+These variables are **only** consumed by the server and therefore **must not**
+be prefixed with `NEXT_PUBLIC_`. In Next.js, any variable that begins with this
+prefix is exposed to the browser. By omitting it we keep the credentials
+private. If in the future you need a variable to be readable on the client you
+can declare it again with the `NEXT_PUBLIC_` prefix, but sensitive values should
+remain server-only.
+
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
 ## Learn More

--- a/src/app/config/constants/constants.ts
+++ b/src/app/config/constants/constants.ts
@@ -1,4 +1,19 @@
-export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL;
-export const DB_NAME = process.env.NEXT_PUBLIC_DB_NAME;
-export const DB_USER = process.env.NEXT_PUBLIC_DB_USER;
-export const DB_PASSWORD = process.env.NEXT_PUBLIC_DB_PASSWORD;
+/**
+ * Retrieves an environment variable and throws an error if it is not defined.
+ * Using this helper prevents runtime errors caused by missing configuration
+ * and avoids leaking sensitive values to the client.
+ */
+const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is not set`);
+  }
+  return value;
+};
+
+// These variables are intended for server-side usage only and therefore do not
+// use the NEXT_PUBLIC_ prefix.
+export const SERVER_URL = requireEnv('SERVER_URL');
+export const DB_NAME = requireEnv('DB_NAME');
+export const DB_USER = requireEnv('DB_USER');
+export const DB_PASSWORD = requireEnv('DB_PASSWORD');


### PR DESCRIPTION
## Summary
- remove `NEXT_PUBLIC_` prefix from env variable names and validate them at runtime
- update env template and README
- clarify why the variables don't use the `NEXT_PUBLIC_` prefix

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844644e58588327bfb9ac7e4fdc26d8