### PR TITLE
feat: add inputMode attribute for numeric input in SearchByText component

### DIFF
--- a/src/app/ui/components/SearchByText/SearchByText.tsx
+++ b/src/app/ui/components/SearchByText/SearchByText.tsx
@@ -39,6 +39,7 @@ const SearchByText: FC = () => {
               </label>
               <input
                 id="tireSize"
+                inputMode="numeric"
                 type="text"
                 placeholder="e.g. 255/55R18"
                 value={value}


### PR DESCRIPTION
This pull request introduces a small enhancement to the `SearchByText` component. The change adds the `inputMode="numeric"` attribute to the input field, improving the user experience by suggesting a numeric keyboard for relevant devices.