### PR TITLE
refactor: simplify RangeSlider component and improve touch event handling

### DIFF
--- a/src/app/ui/components/RangeSlider/RangeSlider.tsx
+++ b/src/app/ui/components/RangeSlider/RangeSlider.tsx
@@ -27,7 +27,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
 }) => {
   const [dragging, setDragging] = useState<'min' | 'max' | null>(null);
   const [localValue, setLocalValue] = useState(value);
-  const [sliderId] = useState(() => `range-slider-${Math.random().toString(36).substr(2, 9)}`);
+  const [sliderId] = useState(() => `range-slider-${Math.random().toString(36).slice(2, 11)}`);
 
   useEffect(() => {
     setLocalValue(value);
@@ -109,7 +109,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
     // Add touch event listeners
     document.addEventListener('touchend', handleTouchEnd);
     document.addEventListener('touchcancel', handleTouchEnd);
-    // Use type assertion to fix the TypeScript error with passive option
+    // Use type assertion to fix the TypeScript error with a passive option
     document.addEventListener(
       'touchmove',
       handleTouchMove as EventListener,
@@ -151,10 +151,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
         className="absolute w-10 h-10 -ml-5 top-0 -mt-1.5 cursor-pointer flex items-center justify-center touch-manipulation"
         style={{ left: `${getPercentage(localValue[0])}%` }}
         onMouseDown={() => handleMouseDown('min')}
-        onTouchStart={e => {
-          // Don't prevent default here to allow the event to be properly recognized
-          handleTouchStart('min');
-        }}
+        onTouchStart={() => handleTouchStart('min')}
       >
         <div className="w-4 h-4 bg-white border-2 border-green-500 rounded-full" />
       </div>
@@ -164,8 +161,7 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
         className="absolute w-10 h-10 -ml-5 top-0 -mt-1.5 cursor-pointer flex items-center justify-center touch-manipulation"
         style={{ left: `${getPercentage(localValue[1])}%` }}
         onMouseDown={() => handleMouseDown('max')}
-        onTouchStart={e => {
-          // Don't prevent default here to allow the event to be properly recognized
+        onTouchStart={() => {
           handleTouchStart('max');
         }}
       >

--- a/src/app/ui/components/RangeSlider/RangeSlider.tsx
+++ b/src/app/ui/components/RangeSlider/RangeSlider.tsx
@@ -15,7 +15,6 @@ interface RangeSliderProps {
   value: [number, number];
   onChange: (value: [number, number]) => void;
   className?: string;
-  id?: string;
 }
 
 const RangeSlider: React.FC<RangeSliderProps> = ({
@@ -25,11 +24,10 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
   value,
   onChange,
   className = '',
-  id,
 }) => {
   const [dragging, setDragging] = useState<'min' | 'max' | null>(null);
   const [localValue, setLocalValue] = useState(value);
-  const [sliderId] = useState(() => id || `range-slider-${min}-${max}-${step}`);
+  const [sliderId] = useState(() => `range-slider-${Math.random().toString(36).substr(2, 9)}`);
 
   useEffect(() => {
     setLocalValue(value);
@@ -111,18 +109,12 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
     // Add touch event listeners
     document.addEventListener('touchend', handleTouchEnd);
     document.addEventListener('touchcancel', handleTouchEnd);
-
-    try {
-      // Try to add the event listener with passive: false
-      document.addEventListener(
-        'touchmove',
-        handleTouchMove as EventListener,
-        { passive: false } as AddEventListenerOptions
-      );
-    } catch (err) {
-      // Fallback for browsers that don't support options
-      document.addEventListener('touchmove', handleTouchMove as EventListener);
-    }
+    // Use type assertion to fix the TypeScript error with passive option
+    document.addEventListener(
+      'touchmove',
+      handleTouchMove as EventListener,
+      { passive: false } as AddEventListenerOptions
+    ); // passive: false allows preventDefault to work
 
     return () => {
       // Remove mouse event listeners
@@ -132,23 +124,16 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
       // Remove touch event listeners
       document.removeEventListener('touchend', handleTouchEnd);
       document.removeEventListener('touchcancel', handleTouchEnd);
-
-      try {
-        // Try to remove with options
-        document.removeEventListener(
-          'touchmove',
-          handleTouchMove as EventListener,
-          { passive: false } as AddEventListenerOptions
-        );
-      } catch (err) {
-        // Fallback for browsers that don't support options
-        document.removeEventListener('touchmove', handleTouchMove as EventListener);
-      }
+      document.removeEventListener(
+        'touchmove',
+        handleTouchMove as EventListener,
+        { passive: false } as AddEventListenerOptions
+      );
     };
   }, [dragging, handlePointerMove, onChange, localValue]);
 
   return (
-    <div id={sliderId} className={`relative h-12 ${className}`} style={{ touchAction: 'none' }}>
+    <div id={sliderId} className={`relative h-7 ${className}`} style={{ touchAction: 'none' }}>
       {/* Track background */}
       <div className="absolute h-2 w-full bg-gray-200 rounded-full top-1/2 -translate-y-1/2" />
 
@@ -163,22 +148,28 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
 
       {/* Minimum thumb */}
       <div
-        className="absolute w-12 h-12 -ml-6 top-0 -mt-3 cursor-pointer flex items-center justify-center touch-manipulation z-10"
+        className="absolute w-10 h-10 -ml-5 top-0 -mt-1.5 cursor-pointer flex items-center justify-center touch-manipulation"
         style={{ left: `${getPercentage(localValue[0])}%` }}
         onMouseDown={() => handleMouseDown('min')}
-        onTouchStart={() => handleTouchStart('min')}
+        onTouchStart={e => {
+          // Don't prevent default here to allow the event to be properly recognized
+          handleTouchStart('min');
+        }}
       >
-        <div className="w-6 h-6 bg-white border-2 border-green-500 rounded-full shadow-md" />
+        <div className="w-4 h-4 bg-white border-2 border-green-500 rounded-full" />
       </div>
 
       {/* Maximum thumb */}
       <div
-        className="absolute w-12 h-12 -ml-6 top-0 -mt-3 cursor-pointer flex items-center justify-center touch-manipulation z-10"
+        className="absolute w-10 h-10 -ml-5 top-0 -mt-1.5 cursor-pointer flex items-center justify-center touch-manipulation"
         style={{ left: `${getPercentage(localValue[1])}%` }}
         onMouseDown={() => handleMouseDown('max')}
-        onTouchStart={() => handleTouchStart('max')}
+        onTouchStart={e => {
+          // Don't prevent default here to allow the event to be properly recognized
+          handleTouchStart('max');
+        }}
       >
-        <div className="w-6 h-6 bg-white border-2 border-green-500 rounded-full shadow-md" />
+        <div className="w-4 h-4 bg-white border-2 border-green-500 rounded-full" />
       </div>
 
       {/* Hidden inputs for form submission */}


### PR DESCRIPTION
This pull request refactors the `RangeSlider` component in `src/app/ui/components/RangeSlider/RangeSlider.tsx` to simplify code, improve performance, and adjust the component's styling. Key changes include removing the `id` prop, simplifying event listener handling, and updating the slider's design.

### Code Simplifications:
* Removed the `id` prop from the `RangeSliderProps` interface and replaced the `sliderId` logic with a unique ID generated using `Math.random`. This reduces complexity and avoids reliance on external `id` values. [[1]](diffhunk://#diff-c7dabce97d6d8ee6677dab46bd267018092a3105ee0745eb85aba000fdd94e06L18) [[2]](diffhunk://#diff-c7dabce97d6d8ee6677dab46bd267018092a3105ee0745eb85aba000fdd94e06L28-R30)

* Simplified touch event listener handling by removing the fallback for browsers that do not support the `passive` option. Instead, a type assertion is used to address TypeScript errors. [[1]](diffhunk://#diff-c7dabce97d6d8ee6677dab46bd267018092a3105ee0745eb85aba000fdd94e06L114-R117) [[2]](diffhunk://#diff-c7dabce97d6d8ee6677dab46bd267018092a3105ee0745eb85aba000fdd94e06L135-R136)

### Design Updates:
* Adjusted the height of the slider container from `h-12` to `h-7` for a more compact design.

* Reduced the size of the slider thumbs from `w-6 h-6` to `w-4 h-4` and their surrounding containers from `w-12 h-12` to `w-10 h-10`, creating a sleeker appearance.

* Updated touch event handling on slider thumbs to avoid calling `preventDefault`, ensuring better compatibility with touch devices.