### PR TITLE
refactor: correct loading state condition in SearchResultsPage for accurate skeleton display

### DIFF
--- a/src/app/(pages)/search-results/container/search-results/search-results.tsx
+++ b/src/app/(pages)/search-results/container/search-results/search-results.tsx
@@ -284,7 +284,7 @@ const SearchResults: FC<SearchResultsProps> = () => {
                             />
                           ) : (
                             <div className="relative">
-                              {!loading ? (
+                              {loading ? (
                                 <ResultsSkeleton count={pageSize} />
                               ) : tiresData.tires.length === 0 ? (
                                 <NoResultsFound


### PR DESCRIPTION
This pull request modifies the `SearchResults` component to improve the user experience during data loading. The key change is reversing the conditional logic to ensure the loading state is handled correctly.

* [`src/app/(pages)/search-results/container/search-results/search-results.tsx`](diffhunk://#diff-cb3e7158f0e01bdf7cb23865102abbd90b83ae42939b1302a98bda730e90a5edL287-R287): Updated the conditional rendering logic in the `SearchResults` component to display the `ResultsSkeleton` when `loading` is true, instead of false. This fixes a potential issue where the loading indicator might not appear as expected.