### PR TITLE
feat: add support for retrieving existing orders by Stripe session ID and include it in order insertion

### DIFF
--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { insertOrderDetailsByOrderId } from '@/repositories/orderDetailsRepository';
-import { insertOrder } from '@/repositories/ordersRepository';
+import { getOrderByStripeSessionId, insertOrder } from '@/repositories/ordersRepository';
 import { fetchTireById, setTiresConditionIdToSoldByIds } from '@/repositories/tiresRepository';
 import { logger } from '@/utils/logger';
 
@@ -128,6 +128,13 @@ export async function GET(req: NextRequest) {
         if (checkoutTestMode) {
           logger.info('Checkout test mode is enabled: skipping DB writes (SC_Order, SC_OrderDetail, Tires updates).');
         } else {
+          // Idempotency check: avoid creating duplicate orders if the user revisits the success URL
+          const existing = await getOrderByStripeSessionId(sessionId as string);
+          if (existing) {
+            sc_order_id = existing.orderId;
+            sc_order_guid = existing.orderGuid;
+            logger.info(`SC_Order already exists for session ${sessionId} (id=${sc_order_id}), skipping insert`);
+          } else {
           // Compute order total in major currency units (decimal)
           const orderTotal = (session.amount_total || 0) / 100;
           const xff = req.headers.get('x-forwarded-for') || '';
@@ -138,6 +145,7 @@ export async function GET(req: NextRequest) {
             store,
             orderTotal,
             customerIP: clientIp,
+            stripeSessionId: sessionId as string,
           });
           sc_order_id = inserted.orderId;
           sc_order_guid = inserted.orderGuid;
@@ -189,6 +197,7 @@ export async function GET(req: NextRequest) {
           } catch (err) {
             logger.error('Failed to update dbo.Tires ConditionId after payment', err as any);
           }
+          } // end else (new order)
         }
       }
     } catch (err) {

--- a/src/repositories/ordersRepository.ts
+++ b/src/repositories/ordersRepository.ts
@@ -1,4 +1,4 @@
-import { VarChar, Decimal, Int } from 'mssql';
+import { VarChar, Decimal, Int, NVarChar } from 'mssql';
 
 import { getPool } from '@/connection/db';
 import { logger } from '@/utils/logger';
@@ -10,11 +10,31 @@ export interface InsertOrderInput {
   customerIP?: string | null; // varchar(20)
   paymentMethodId?: number | null; // optional, unknown mapping
   paymentStatusId?: number | null; // optional, unknown mapping
+  stripeSessionId?: string | null; // Stripe Checkout Session ID for idempotency
 }
 
 export interface InsertOrderResult {
   orderId: number;
   orderGuid: string;
+}
+
+/**
+ * Returns the existing SC_Order for a given Stripe session ID, or null if not found.
+ */
+export async function getOrderByStripeSessionId(
+  stripeSessionId: string
+): Promise<InsertOrderResult | null> {
+  const pool = await getPool();
+  const request = pool.request();
+  request.input('StripeSessionId', NVarChar(255), stripeSessionId);
+  const result = await request.query(`
+    SELECT TOP 1 Id AS orderId, CAST(OrderGuid AS NVARCHAR(36)) AS orderGuid
+    FROM dbo.SC_Order
+    WHERE StripeSessionId = @StripeSessionId
+  `);
+  const row = result.recordset?.[0] as any;
+  if (!row) return null;
+  return { orderId: row.orderId as number, orderGuid: row.orderGuid as string };
 }
 
 /**
@@ -45,6 +65,11 @@ export async function insertOrder(input: InsertOrderInput): Promise<InsertOrderR
     const paymentStatusId =
       typeof input.paymentStatusId === 'number' ? input.paymentStatusId : 2; // default 2
 
+    const stripeSessionId =
+      typeof input.stripeSessionId === 'string' && input.stripeSessionId.trim()
+        ? input.stripeSessionId.trim().slice(0, 255)
+        : null;
+
     // Bind parameters (always bind, even if null)
     request.input('OrderSatusId', Int, input.orderSatusId);
     request.input('Store', VarChar(50), store);
@@ -52,6 +77,7 @@ export async function insertOrder(input: InsertOrderInput): Promise<InsertOrderR
     request.input('CustomerIP', VarChar(20), customerIP as any);
     request.input('PaymentMethodId', Int, paymentMethodId);
     request.input('PaymentStatusId', Int, paymentStatusId);
+    request.input('StripeSessionId', NVarChar(255), stripeSessionId as any);
 
     // Perform a concurrency-safe insert with a computed next OrdenNumber
     const sql = `
@@ -73,7 +99,8 @@ export async function insertOrder(input: InsertOrderInput): Promise<InsertOrderR
         ShippingAddressId,
         ShippingStatusId,
         OrderTotal,
-        CustomerIP
+        CustomerIP,
+        StripeSessionId
       )
       OUTPUT INSERTED.Id AS orderId, INSERTED.OrderGuid AS orderGuid
       VALUES (
@@ -89,7 +116,8 @@ export async function insertOrder(input: InsertOrderInput): Promise<InsertOrderR
         0,             -- ShippingAddressId
         1,             -- ShippingStatusId
         @OrderTotal,
-        @CustomerIP
+        @CustomerIP,
+        @StripeSessionId
       );`;
 
     const result = await request.query(sql);


### PR DESCRIPTION
This pull request implements idempotency for order creation in the checkout flow by associating each order with a Stripe Checkout Session ID. This prevents duplicate orders from being created if a user revisits the success URL. The main changes include adding a new database field for the Stripe session ID, updating the order insertion logic, and introducing a query to check for existing orders by session ID.

**Order idempotency and Stripe session tracking:**

* Added a new `stripeSessionId` field to the `InsertOrderInput` interface and the `insertOrder` function, and updated the database insert to store this value in the `dbo.SC_Order` table. [[1]](diffhunk://#diff-60f8f0831ee9475d942a7bf49eeaf9c5fe3b6ca238ff5142c1e5b72b2b55e244R13-R39) [[2]](diffhunk://#diff-60f8f0831ee9475d942a7bf49eeaf9c5fe3b6ca238ff5142c1e5b72b2b55e244R68-R80) [[3]](diffhunk://#diff-60f8f0831ee9475d942a7bf49eeaf9c5fe3b6ca238ff5142c1e5b72b2b55e244L76-R103) [[4]](diffhunk://#diff-60f8f0831ee9475d942a7bf49eeaf9c5fe3b6ca238ff5142c1e5b72b2b55e244L92-R120)
* Implemented the `getOrderByStripeSessionId` function to retrieve an existing order by Stripe session ID, ensuring duplicate orders are not created for the same session.
* Updated the checkout session route (`src/app/api/checkout/session/route.ts`) to check for an existing order before inserting a new one, skipping the insert if an order already exists for the session. [[1]](diffhunk://#diff-681bc524901d8cd5446e2cc68f10734d91795cdbe9c6259cbda6854c2939bea4L4-R4) [[2]](diffhunk://#diff-681bc524901d8cd5446e2cc68f10734d91795cdbe9c6259cbda6854c2939bea4R130-R136) [[3]](diffhunk://#diff-681bc524901d8cd5446e2cc68f10734d91795cdbe9c6259cbda6854c2939bea4R148) [[4]](diffhunk://#diff-681bc524901d8cd5446e2cc68f10734d91795cdbe9c6259cbda6854c2939bea4R200)

**Other minor changes:**

* Added `NVarChar` import to support the new field type for `stripeSessionId`.