### PR TITLE
feat: add login manifest for PWA support

### DIFF
--- a/public/login-manifest.json
+++ b/public/login-manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "MrGoma Staff Portal",
+  "short_name": "MrGoma Staff",
+  "description": "Portal de colaboradores – MrGoma Tires",
+  "start_url": "/login",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#16a34a",
+  "icons": [
+    {
+      "src": "/desk-logo.png",
+      "sizes": "any",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/app/(sellers)/login/page.tsx
+++ b/src/app/(sellers)/login/page.tsx
@@ -5,6 +5,7 @@ import Login from '@/app/(sellers)/login/container/Login';
 export const metadata: Metadata = {
   title: 'MrGoma Tires | Seller Portal',
   robots: { index: false, follow: false },
+  manifest: '/login-manifest.json',
 };
 
 const LoginPage: NextPage = () => {


### PR DESCRIPTION
This pull request adds support for a web app manifest to the seller login page, enabling Progressive Web App (PWA) features such as installability and theming. The main changes include creating a new manifest file and linking it in the page metadata.

Manifest support:

* Added a new `public/login-manifest.json` file defining the PWA manifest for the staff portal, including app name, description, colors, and icon configuration.
* Updated the `src/app/(sellers)/login/page.tsx` file to reference the new manifest in the page metadata, ensuring browsers can detect and use the manifest.