### PR TITLE
feat: add tire code filter to dashboard and send code in WhatsApp cart message

### DIFF
--- a/src/app/(sellers)/dashboard/container/Dashboard.tsx
+++ b/src/app/(sellers)/dashboard/container/Dashboard.tsx
@@ -7,6 +7,7 @@ import { TireSelector } from '@/app/ui/components/CollapsibleSearchBar/component
 import { useTireSearch } from '@/app/ui/components/CollapsibleSearchBar/hooks/useTireSearch';
 import { AdjustmentsHorizontalIcon } from '@/app/ui/components/Icons/Icons';
 import { FiltersMobile, TopFilters } from '@/app/ui/sections';
+import { CodeFilterInput } from '@/app/ui/sections/TopFilters/TopFilters';
 import DashboardCartModal from '@/app/ui/sections/DashboardCartModal/DashboardCartModal';
 import DashboardTableContainer from '@/app/ui/sections/DashboardTableContainer/DashboardTableContainer';
 
@@ -56,8 +57,10 @@ const Dashboard = () => {
                   showStoreFilter={true}
                   inlineTireSize
                   showLocalFilter
+                  showCodeFilter
                 />
                 <div className="lg:hidden border-t border-gray-50 pt-3 space-y-3">
+                  <CodeFilterInput redirectBasePath="dashboard" fullWidth />
                   <TireSelector
                     selectedFilters={mobileTireFilters}
                     onFilterChangeAction={handleMobileTireChange}

--- a/src/app/context/CartContext.tsx
+++ b/src/app/context/CartContext.tsx
@@ -13,6 +13,7 @@ import {
 // Define the cart item type
 export interface CartItem {
   id: string | number;
+  code?: string;
   name: string;
   price: number;
   condition?: string;
@@ -25,6 +26,7 @@ export interface CartItem {
 // Define the cart context type
 export interface AddToCartProduct {
   id: string | number;
+  code?: string;
   name: string;
   price: number | string;
   condition?: string;
@@ -103,6 +105,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
           ...prevItems,
           {
             brand: product.brand,
+            code: product.code,
             condition: product.condition,
             brandId: product.brandId,
             id: prodId,

--- a/src/app/ui/components/DashboardTable/DashboardTable.tsx
+++ b/src/app/ui/components/DashboardTable/DashboardTable.tsx
@@ -45,6 +45,7 @@ function AddToCartButton({ row }: { row: DocumentRecord }) {
       const price = typeof priceRaw === 'string' ? parseFloat(priceRaw) || 0 : Number(priceRaw) || 0;
       addToCart({
         id: tireId,
+        code: String(row.Code ?? ''),
         name,
         price,
         brand,
@@ -52,7 +53,7 @@ function AddToCartButton({ row }: { row: DocumentRecord }) {
         images: data?.images,
       });
     } catch {
-      addToCart({ id: tireId, name, price: 0, brand });
+      addToCart({ id: tireId, code: String(row.Code ?? ''), name, price: 0, brand });
     } finally {
       setLoading(false);
     }

--- a/src/app/ui/sections/DashboardCartModal/DashboardCartModal.tsx
+++ b/src/app/ui/sections/DashboardCartModal/DashboardCartModal.tsx
@@ -33,7 +33,8 @@ const DashboardCartFooter: FC = () => {
       ...cartItems.map(item => {
         const price = item.price > 0 ? ` — $${item.price.toFixed(2)}` : '';
         const store = item.condition ? ` | ${item.condition}` : '';
-        return `• ${item.name} (ID: ${item.id}) x${item.quantity}${price}${store}`;
+        const ref = item.code ? `Code: ${item.code}` : `ID: ${item.id}`;
+        return `• ${item.name} (${ref}) x${item.quantity}${price}${store}`;
       }),
       '',
     ];

--- a/src/app/ui/sections/FiltersMobile/hooks/useFilters.tsx
+++ b/src/app/ui/sections/FiltersMobile/hooks/useFilters.tsx
@@ -471,6 +471,7 @@ export const useFilters = (
     params.delete('w');
     params.delete('s');
     params.delete('d');
+    params.delete('code');
 
     params.set('page', '1');
 

--- a/src/app/ui/sections/TopFilters/TopFilters.tsx
+++ b/src/app/ui/sections/TopFilters/TopFilters.tsx
@@ -2,11 +2,81 @@
 
 import { FC, useState, useRef, useEffect } from 'react';
 
+import { useRouter, useSearchParams } from 'next/navigation';
+
 import { TireSelector } from '@/app/ui/components/CollapsibleSearchBar/components/TireSelector';
 import { useTireSearch } from '@/app/ui/components/CollapsibleSearchBar/hooks/useTireSearch';
 import { FilterBody } from '@/app/ui/sections/';
 import { filtersItems } from '@/app/ui/sections/FiltersMobile/FiltersItems';
 import { useFilters } from '@/app/ui/sections/FiltersMobile/hooks/useFilters';
+
+export const CodeFilterInput: FC<{ redirectBasePath: string; fullWidth?: boolean }> = ({
+  redirectBasePath,
+  fullWidth = false,
+}) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [value, setValue] = useState(searchParams.get('code') ?? '');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isActive = value.length > 0;
+
+  const pushCode = (code: string) => {
+    const params = new URLSearchParams(window.location.search);
+    if (code) {
+      params.set('code', code);
+    } else {
+      params.delete('code');
+    }
+    params.set('page', '1');
+    router.push(`/${redirectBasePath}?${params.toString()}`, { scroll: false });
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const digits = e.target.value.replace(/\D/g, '');
+    setValue(digits);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => pushCode(digits), 400);
+  };
+
+  const handleClear = () => {
+    setValue('');
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    pushCode('');
+  };
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-md border px-3 ${
+        fullWidth ? 'w-full py-2.5' : 'py-1'
+      } ${isActive ? 'border-green-500 bg-green-50' : 'border-gray-300 bg-white'}`}
+    >
+      <input
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        enterKeyHint="search"
+        placeholder="Tire Code"
+        value={value}
+        onChange={handleChange}
+        maxLength={20}
+        style={{ fontSize: '16px' }}
+        className={`${fullWidth ? 'flex-1' : 'w-24'} bg-transparent outline-none placeholder-gray-400 leading-none ${
+          isActive ? 'text-green-700' : 'text-gray-700'
+        }`}
+      />
+      {isActive && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="text-green-600 hover:text-green-800 font-bold leading-none cursor-pointer text-base"
+          aria-label="Clear tire code filter"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+};
 
 export const TopFilters: FC<{
   redirectBasePath: string;
@@ -15,6 +85,7 @@ export const TopFilters: FC<{
   showStoreFilter?: boolean;
   inlineTireSize?: boolean;
   showLocalFilter?: boolean;
+  showCodeFilter?: boolean;
 }> = ({
   redirectBasePath,
   apiBasePath = '/api',
@@ -22,6 +93,7 @@ export const TopFilters: FC<{
   showStoreFilter = false,
   inlineTireSize = false,
   showLocalFilter = false,
+  showCodeFilter = false,
 }) => {
   const {
     rangeInputs,
@@ -328,7 +400,8 @@ export const TopFilters: FC<{
           )}
         </div>
 
-        <div className="ml-auto pl-2 self-center">
+        <div className="ml-auto pl-2 self-center flex items-center gap-2">
+          {showCodeFilter && <CodeFilterInput redirectBasePath={redirectBasePath} />}
           <button
             type="button"
             onClick={() => {

--- a/src/app/utils/filterUtils.ts
+++ b/src/app/utils/filterUtils.ts
@@ -28,6 +28,7 @@ export function buildTireFilters(searchParams: URLSearchParams): TireFilters {
   const storesParam = searchParams.get('stores');
   const kindSaleParam = searchParams.get('kindSale');
   const localParam = searchParams.get('local');
+  const codeParam = searchParams.get('code');
 
   // Tire dimensions
   const width = searchParams.get('w');
@@ -61,6 +62,8 @@ export function buildTireFilters(searchParams: URLSearchParams): TireFilters {
   if (storesParam) filters.stores = storesParam.split(',').filter(Boolean);
   if (kindSaleParam) filters.kindSale = kindSaleParam.split(',').filter(Boolean);
   if (localParam) filters.local = localParam.split(',').filter(Boolean);
+  // Only digits allowed — reject anything else (injection/XSS protection)
+  if (codeParam && /^\d+$/.test(codeParam)) filters.tireCode = codeParam;
 
   // Add dimension parameters
   if (width) filters.width = width;

--- a/src/repositories/tiresRepository.ts
+++ b/src/repositories/tiresRepository.ts
@@ -102,6 +102,11 @@ function buildFiltersClause(filters: TireFilters): { clause: string; params: Sql
     params.push({ name: 'maxRemainingLife', type: Int, value: filters.maxRemainingLife });
   }
 
+  if (filters.tireCode) {
+    clause += ' AND Code = @tireCode';
+    params.push({ name: 'tireCode', type: VarChar, value: filters.tireCode });
+  }
+
   return { clause, params };
 }
 
@@ -155,6 +160,7 @@ export type TireFilters = {
   stores?: string[];
   kindSale?: string[];
   local?: string[];
+  tireCode?: string;
 };
 
 export type TireRangeResult = {


### PR DESCRIPTION
- WhatsApp message now shows Code instead of internal ID per tire
- Dashboard filter bar gains a numeric-only Tire Code input (desktop + mobile)
- Mobile input uses fontSize 16px to prevent iOS Safari zoom on focus
- Backend validates code param as digits-only before building SQL clause