### PR TITLE
feat(tires): highlight active brand chip on /tires?brand= and /tires/brands/[brand]; auto-scroll active chip into view

### DIFF
--- a/src/app/(shop)/tires/brands/[brand]/page.tsx
+++ b/src/app/(shop)/tires/brands/[brand]/page.tsx
@@ -1,8 +1,11 @@
+import { Suspense } from 'react';
+
 import { notFound } from 'next/navigation';
 
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { BrowseFilters } from '@/app/(shop)/tires/container/BrowseFilters/BrowseFilters';
 import { TireGrid } from '@/app/(shop)/tires/container/TireGrid/TireGrid';
 import { TiresData } from '@/app/interfaces/tires';
 import { BrandImage } from '@/app/ui/components';
@@ -58,7 +61,10 @@ export default async function BrandCategoryPage({
   const brandName = await getBrandName(brandSlug);
   if (!brandName) notFound();
 
-  const [result] = await Promise.all([fetchTires(0, 24, { brands: [brandName] })]);
+  const [result, allBrands] = await Promise.all([
+    fetchTires(0, 24, { brands: [brandName] }),
+    fetchBrands().catch(() => [] as string[]),
+  ]);
   const tires = (result.records as TiresData[]).map(transformTireData);
   const totalCount = result.totalCount;
   const brandId = result.records.length > 0 ? ((result.records[0] as any).BrandId as number) : undefined;
@@ -138,6 +144,10 @@ export default async function BrandCategoryPage({
             ))}
           </div>
         </div>
+
+        <Suspense fallback={null}>
+          <BrowseFilters brands={allBrands} activeBrand={brandName} />
+        </Suspense>
 
         {/* Tire grid */}
         <section className="py-10">

--- a/src/app/(shop)/tires/container/BrowseFilters/BrowseFilters.tsx
+++ b/src/app/(shop)/tires/container/BrowseFilters/BrowseFilters.tsx
@@ -11,12 +11,14 @@ type RouteVariant = 'browse' | 'new' | 'used';
 interface BrowseFiltersProps {
   brands: string[];
   variant?: RouteVariant;
+  activeBrand?: string;
   className?: string;
 }
 
 export const BrowseFilters: FC<BrowseFiltersProps> = ({
   brands,
   variant = 'browse',
+  activeBrand,
   className = '',
 }) => {
   const isNew = variant === 'new';
@@ -31,7 +33,11 @@ export const BrowseFilters: FC<BrowseFiltersProps> = ({
             <p className="text-[10px] font-bold text-gray-400 uppercase tracking-[0.18em] mb-2.5">
               Browse by brand
             </p>
-            <BrandScroller brands={brands} />
+            {isBrowse && !activeBrand ? (
+              <BrandScrollerWithSearchParam brands={brands} />
+            ) : (
+              <BrandScroller brands={brands} activeBrand={activeBrand} />
+            )}
           </div>
         )}
         <div>
@@ -127,10 +133,25 @@ const ClearIcon = () => (
   </svg>
 );
 
-const BrandScroller: FC<{ brands: string[] }> = ({ brands }) => {
+interface BrandScrollerProps {
+  brands: string[];
+  activeBrand?: string;
+}
+
+// Variant that reads ?brand= from URL — only used inside variant='browse' (route /tires)
+const BrandScrollerWithSearchParam: FC<BrandScrollerProps> = ({ brands, activeBrand }) => {
+  const searchParams = useSearchParams();
+  const fromParam = searchParams?.get('brand') || '';
+  return <BrandScroller brands={brands} activeBrand={activeBrand || fromParam} />;
+};
+
+const BrandScroller: FC<BrandScrollerProps> = ({ brands, activeBrand }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const activeChipRef = useRef<HTMLAnchorElement | null>(null);
   const [progress, setProgress] = useState(0);
   const [hasOverflow, setHasOverflow] = useState(false);
+
+  const active = (activeBrand || '').toLowerCase();
 
   const updateProgress = useCallback(() => {
     const el = scrollRef.current;
@@ -152,6 +173,23 @@ const BrandScroller: FC<{ brands: string[] }> = ({ brands }) => {
     };
   }, [updateProgress, brands.length]);
 
+  // Auto-scroll active chip into view on mount
+  useEffect(() => {
+    const chip = activeChipRef.current;
+    const container = scrollRef.current;
+    if (!chip || !container) return;
+    const chipLeft = chip.offsetLeft;
+    const chipRight = chipLeft + chip.offsetWidth;
+    const viewLeft = container.scrollLeft;
+    const viewRight = viewLeft + container.clientWidth;
+    if (chipLeft < viewLeft || chipRight > viewRight) {
+      container.scrollTo({
+        left: Math.max(0, chipLeft - container.clientWidth / 2 + chip.offsetWidth / 2),
+        behavior: 'smooth',
+      });
+    }
+  }, [active]);
+
   const thumbLeft = progress * 72;
 
   return (
@@ -160,15 +198,26 @@ const BrandScroller: FC<{ brands: string[] }> = ({ brands }) => {
         ref={scrollRef}
         className="flex gap-2 overflow-x-auto pb-3 sm:pb-2 [scrollbar-width:thin] [scrollbar-color:#d1d5db_#f3f4f6] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:hover:bg-gray-400"
       >
-        {brands.map(brand => (
-          <a
-            key={brand}
-            href={`/tires/brands/${slugify(brand)}`}
-            className="shrink-0 inline-flex items-center px-3 py-1.5 rounded-full border border-gray-200 text-xs font-semibold text-gray-700 hover:border-green-600 hover:text-green-700 hover:bg-green-50 transition-colors duration-150 whitespace-nowrap"
-          >
-            {brand}
-          </a>
-        ))}
+        {brands.map(brand => {
+          const isActive = brand.toLowerCase() === active;
+          return (
+            <a
+              key={brand}
+              ref={isActive ? activeChipRef : undefined}
+              href={isActive ? '/tires' : `/tires/brands/${slugify(brand)}`}
+              aria-pressed={isActive}
+              aria-label={isActive ? `Clear ${brand} filter` : `Browse ${brand} tires`}
+              className={`shrink-0 inline-flex items-center gap-1 px-3 py-1.5 rounded-full border text-xs font-semibold transition-colors duration-150 whitespace-nowrap ${
+                isActive
+                  ? 'border-green-600 bg-green-600 text-white hover:bg-green-700 hover:border-green-700'
+                  : 'border-gray-200 text-gray-700 hover:border-green-600 hover:text-green-700 hover:bg-green-50'
+              }`}
+            >
+              {brand}
+              {isActive && <ClearIcon />}
+            </a>
+          );
+        })}
       </div>
 
       {hasOverflow && (

--- a/src/app/(shop)/tires/new/page.tsx
+++ b/src/app/(shop)/tires/new/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -124,7 +126,9 @@ export default async function NewTiresPage() {
           </div>
         </section>
 
-        <BrowseFilters brands={brands} variant="new" />
+        <Suspense fallback={null}>
+          <BrowseFilters brands={brands} variant="new" />
+        </Suspense>
 
         {/* Why new tires */}
         <section className="py-16 border-b border-gray-100">

--- a/src/app/(shop)/tires/used/page.tsx
+++ b/src/app/(shop)/tires/used/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -124,7 +126,9 @@ export default async function UsedTiresPage() {
           </div>
         </section>
 
-        <BrowseFilters brands={brands} variant="used" />
+        <Suspense fallback={null}>
+          <BrowseFilters brands={brands} variant="used" />
+        </Suspense>
 
         {/* Why used tires */}
         <section className="py-16 border-b border-gray-100">


### PR DESCRIPTION
This pull request improves the tire brand browsing experience by enhancing the `BrowseFilters` component and its integration across the shop pages. The changes focus on better handling of active brand filters, improved accessibility, and a more user-friendly UI for brand selection. Additionally, the `BrowseFilters` component is now loaded asynchronously with React's `Suspense` for improved performance.

**Enhancements to brand filtering and browsing:**

- The `BrowseFilters` component now accepts an `activeBrand` prop, allowing it to highlight the currently selected brand and provide a way to clear the filter. The brand scroller auto-scrolls the active brand chip into view and updates the UI to clearly indicate the active filter. [[1]](diffhunk://#diff-b66dfa2ce072bc8c582d043457c90277ac68843fd705c480331dba253ebbf677R14-R21) [[2]](diffhunk://#diff-b66dfa2ce072bc8c582d043457c90277ac68843fd705c480331dba253ebbf677L130-R155) [[3]](diffhunk://#diff-b66dfa2ce072bc8c582d043457c90277ac68843fd705c480331dba253ebbf677L34-R40) [[4]](diffhunk://#diff-b66dfa2ce072bc8c582d043457c90277ac68843fd705c480331dba253ebbf677R176-R192) [[5]](diffhunk://#diff-b66dfa2ce072bc8c582d043457c90277ac68843fd705c480331dba253ebbf677L163-R220)
- The brand list for filters is now fetched and passed down to `BrowseFilters` in the brand category page, ensuring the filter options are always up-to-date. ([src/app/(shop)/tires/brands/[brand]/page.tsxL61-R67](diffhunk://#diff-e7e12e18b2f1299f8eb776c3b57f00dca089195174159ea8f5ecd0e0b330672cL61-R67))

**Performance and code structure improvements:**

- The `BrowseFilters` component is now wrapped in a `Suspense` boundary on all relevant pages (`brand`, `new`, and `used` tires), enabling asynchronous loading and potentially improving initial page render times. ([src/app/(shop)/tires/brands/[brand]/page.tsxR1-R8](diffhunk://#diff-e7e12e18b2f1299f8eb776c3b57f00dca089195174159ea8f5ecd0e0b330672cR1-R8), [src/app/(shop)/tires/brands/[brand]/page.tsxR148-R151](diffhunk://#diff-e7e12e18b2f1299f8eb776c3b57f00dca089195174159ea8f5ecd0e0b330672cR148-R151), [[1]](diffhunk://#diff-b63acc5b38886183bf23e8a090434c7a998a19a6e2e18fe681bc1d96e8b1414bR1-R2) [[2]](diffhunk://#diff-b63acc5b38886183bf23e8a090434c7a998a19a6e2e18fe681bc1d96e8b1414bR129-R131) [[3]](diffhunk://#diff-153e130dfd075804d4d8a6f75d82927e77de6ea71067c8fedd6766d7937900e1R1-R2) [[4]](diffhunk://#diff-153e130dfd075804d4d8a6f75d82927e77de6ea71067c8fedd6766d7937900e1R129-R131)