### PR TITLE
fix(images): serve remote tire photos unoptimized to dodge Vercel quota

### DIFF
--- a/src/app/(shop)/checkout/container/Checkout/Checkout.tsx
+++ b/src/app/(shop)/checkout/container/Checkout/Checkout.tsx
@@ -636,6 +636,8 @@ export default function Checkout() {
                                       width={64}
                                       height={64}
                                       className="h-full w-full object-cover object-center"
+                                      // Remote tire photos skip Vercel's optimizer (quota / 402).
+                                      unoptimized={item.image.startsWith('http')}
                                     />
                                   ) : (
                                     <div className="flex h-full w-full items-center justify-center bg-gray-100 text-xs text-gray-500">

--- a/src/app/ui/components/ProductCarouselMiniature/ProductCarouselMiniature.tsx
+++ b/src/app/ui/components/ProductCarouselMiniature/ProductCarouselMiniature.tsx
@@ -31,6 +31,9 @@ const ProductCarouselMiniature: FC<ProductImageProps> = ({ product, isHovered })
         }`}
         alt={safeAlt}
         src={safeSrc}
+        // Remote tire photos load straight from our image host (skip Vercel's
+        // optimizer to avoid the optimization quota / 402 errors).
+        unoptimized={safeSrc.startsWith('http')}
         title={safeAlt}
         aria-label={safeAlt}
         priority

--- a/src/app/ui/components/ProductImage/ProductImage.tsx
+++ b/src/app/ui/components/ProductImage/ProductImage.tsx
@@ -55,6 +55,10 @@ const ProductImage: FC<ProductImageProps> = ({ product, priority = false }) => {
         className={`w-full object-contain object-center transition ease-in-out hover:scale-105 duration-300`}
         alt={product.imageAlt || product.brand || 'Tire image'}
         src={imgSrc}
+        // Remote tire photos are served by our own image host; bypass Vercel's
+        // image optimizer for them (avoids the optimization quota / 402 errors).
+        // Local assets (e.g. the fallback) keep optimization.
+        unoptimized={imgSrc.startsWith('http')}
         onError={handleImageError}
         priority={priority}
         loading={priority ? undefined : 'lazy'}

--- a/src/app/ui/sections/CartModal/CartModal.tsx
+++ b/src/app/ui/sections/CartModal/CartModal.tsx
@@ -77,6 +77,8 @@ const CartModal: FC<{ footer?: React.ReactNode }> = ({ footer }) => {
                               width={64}
                               height={64}
                               className="w-full h-full object-center object-cover"
+                              // Remote tire photos skip Vercel's optimizer (quota / 402).
+                              unoptimized={item.image.startsWith('http')}
                             />
                           ) : (
                             <div className="w-full h-full bg-gray-200 flex items-center justify-center">

--- a/src/app/ui/sections/ProductCarousel/ProductCarousel.tsx
+++ b/src/app/ui/sections/ProductCarousel/ProductCarousel.tsx
@@ -102,6 +102,9 @@ const ProductCarousel: FC<TireInformationProps> = ({ singleTire }) => {
               className="object-contain object-center"
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 600px"
               priority={false}
+              // Remote tire photos load straight from our image host (skip
+              // Vercel's optimizer to avoid the optimization quota / 402 errors).
+              unoptimized={current.src.startsWith('http')}
             />
             <div className="pointer-events-none absolute top-2 left-2 z-30">
               <ProductCondition condition={singleTire.condition} />


### PR DESCRIPTION
Production was returning broken tire images: Vercel's image optimizer responds 402 OPTIMIZED_IMAGE_REQUEST_PAYMENT_REQUIRED once the plan's optimization quota is exhausted, so every uncached /_next/image request fails. Local dev optimizes on-device, which is why it only broke in prod.

Tire photos already come from our own image host (usedtires.online), so route those (any http/https src) straight to the browser with `unoptimized`, bypassing the optimizer. Local assets keep optimization. Applied to the card, detail gallery (main + thumbnails), cart modal and checkout line items.