### PR TITLE
fix(ui): soften /tires add-to-cart button and keep loaders spinning

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+/* Explicit keyframe for loading spinners so rotation never depends on
+   Tailwind's `spin` keyframe being resolvable under the reduce-motion
+   override below. */
+@keyframes mg-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (prefers-reduced-motion: no-preference) {
   :root {
     scroll-behavior: smooth;
@@ -18,6 +27,14 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+  }
+
+  /* Loading spinners must keep spinning — a frozen spinner reads as broken,
+     and it signals active progress, not decoration. Full shorthand with an
+     explicit keyframe so it beats the blanket override above regardless of
+     Tailwind's own `spin` keyframe. */
+  .animate-spin {
+    animation: mg-spin 0.8s linear infinite !important;
   }
 }
 

--- a/src/app/ui/sections/TireCard/TireCard.tsx
+++ b/src/app/ui/sections/TireCard/TireCard.tsx
@@ -122,7 +122,7 @@ const TireCard: FC<TireCardProps> = ({ products }) => {
                       data-track="add_to_cart"
                       data-track-category="cart"
                       data-track-label={titleText}
-                      className="flex items-center gap-2 pl-3 pr-4 py-2 bg-green-600 text-white text-sm font-black rounded-full hover:bg-green-700 disabled:opacity-50 transition-colors whitespace-nowrap"
+                      className="flex items-center gap-2 pl-3 pr-4 py-2 bg-green-600 text-white text-sm font-semibold rounded-full cursor-pointer hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
                     >
                       <CartIcon />
                       {productInCart ? '✓ In Cart' : 'Add to Cart'}
@@ -186,7 +186,7 @@ const TireCard: FC<TireCardProps> = ({ products }) => {
                     data-track="add_to_cart"
                     data-track-category="cart"
                     data-track-label={titleText}
-                    className="w-full flex items-center justify-center gap-2 py-3 bg-green-600 text-white text-sm font-black rounded-full hover:bg-green-700 disabled:opacity-50 transition-colors"
+                    className="w-full flex items-center justify-center gap-2 py-3 bg-green-600 text-white text-sm font-semibold rounded-full cursor-pointer hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     <CartIcon />
                     {productInCart ? '✓ IN CART' : 'ADD TO CART'}


### PR DESCRIPTION
- TireCard "Add to Cart" (desktop + mobile): font-black → font-semibold and add cursor-pointer / disabled:cursor-not-allowed (it was too bold and had no pointer cursor on hover).
- globals.css: the reduce-motion block disabled every animation via `!important`, which froze loading spinners (e.g. the home size-selector spinner). Add an explicit `mg-spin` keyframe and re-enable `.animate-spin` under reduced motion so progress spinners keep rotating (a frozen spinner reads as broken). Fixes all loaders site-wide.