### PR TITLE
Feat/home filters detail zoom

### DIFF
--- a/src/app/(shop)/tires/container/BrowseFilters/BrowseFilters.tsx
+++ b/src/app/(shop)/tires/container/BrowseFilters/BrowseFilters.tsx
@@ -138,10 +138,15 @@ interface BrandScrollerProps {
   activeBrand?: string;
 }
 
-// Variant that reads ?brand= from URL — only used inside variant='browse' (route /tires)
+// Variant that reads the active brand from the URL — only used inside
+// variant='browse' (route /tires). Highlights from either the singular `?brand=`
+// (SEO/browse links) or a single `?brands=` value (the multi-filter scheme the
+// home "More filters" panel uses), so arriving with one brand lights up the chip.
 const BrandScrollerWithSearchParam: FC<BrandScrollerProps> = ({ brands, activeBrand }) => {
   const searchParams = useSearchParams();
-  const fromParam = searchParams?.get('brand') || '';
+  const brandsParam = searchParams?.get('brands') || '';
+  const singleBrand = brandsParam && !brandsParam.includes(',') ? brandsParam : '';
+  const fromParam = searchParams?.get('brand') || singleBrand || '';
   return <BrandScroller brands={brands} activeBrand={activeBrand || fromParam} />;
 };
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,24 @@
   }
 }
 
+/* Subtle one-time attention halo for onboarding cues (e.g. the 3D selector
+   button/hint). Soft green glow that pulses a few times and stops on its own,
+   so it never nags. Fully suppressed under reduce-motion by the blanket rule
+   below (iteration-count forced to 1 + near-zero duration). */
+@keyframes mg-attention {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.28);
+  }
+}
+
+.mg-attention {
+  animation: mg-attention 1.6s ease-in-out 3;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   :root {
     scroll-behavior: smooth;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,6 +62,23 @@
   }
 }
 
+/* Center the top-layer "More filters" popover as a modal. Tailwind's Preflight
+   resets `margin: 0` on every element, which would otherwise override the UA
+   popover centering (`:where([popover]) { margin: auto }`), pinning it to the
+   top-left — so restore it explicitly. The mobile bottom-sheet styles are set
+   inline and win over this. */
+.mg-popover {
+  margin: auto;
+  height: fit-content;
+}
+
+/* Dim, lightly-blurred backdrop so it reads as a modal/bottom-sheet over the
+   hero. */
+.mg-popover::backdrop {
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(2px);
+}
+
 input[type='range'] {
   -webkit-appearance: none;
   appearance: none;

--- a/src/app/ui/components/HomeMoreFilters/HomeMoreFilters.tsx
+++ b/src/app/ui/components/HomeMoreFilters/HomeMoreFilters.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+
+import RangeSlider from '@/app/ui/components/RangeSlider/RangeSlider';
+import { filtersItems } from '@/app/ui/sections/FiltersMobile/FiltersItems';
+
+/** Extra (non-size) filters the home search can forward to /tires. `null` price
+ *  bounds mean "not constrained" so they are omitted from the URL. */
+export interface HomeExtraFilters {
+  brands: string[];
+  condition: string[];
+  minPrice: number | null;
+  maxPrice: number | null;
+}
+
+interface HomeMoreFiltersProps {
+  /** Currently applied filters (drives the count badge + seeds the draft). */
+  value: HomeExtraFilters;
+  /** Stage the draft filters (the main Search button runs the actual search). */
+  onApply: (filters: HomeExtraFilters) => void;
+}
+
+const conditionOptions =
+  filtersItems.find(s => s.id === 'condition')?.options ?? [
+    { value: 'new', label: 'New' },
+    { value: 'used', label: 'Used' },
+  ];
+
+const SlidersIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M4 6h11M19 6h1M4 12h1M9 12h11M4 18h7M15 18h5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="17" cy="6" r="2.2" stroke="currentColor" strokeWidth="2" />
+    <circle cx="7" cy="12" r="2.2" stroke="currentColor" strokeWidth="2" />
+    <circle cx="13" cy="18" r="2.2" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
+/**
+ * "More filters" entry point for the home hero. The size selector stays the
+ * primary CTA; this is a secondary, progressively-disclosed panel for Brand /
+ * Condition / Price.
+ *
+ * The panel is a native Popover (`popover="auto"`), so it renders in the top
+ * layer — it sits above the AI chat without portals or z-index hacks — and gets
+ * light-dismiss + Escape for free. CSS anchor positioning is not Baseline yet,
+ * so the panel is placed with a small JS helper (desktop dropdown) and styled as
+ * a bottom sheet on mobile.
+ */
+const HomeMoreFilters: FC<HomeMoreFiltersProps> = ({ value, onApply }) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const loadedRef = useRef(false);
+
+  const [allBrands, setAllBrands] = useState<string[]>([]);
+  const [bounds, setBounds] = useState<[number, number] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const [brands, setBrands] = useState<string[]>(value.brands);
+  const [condition, setCondition] = useState<string[]>(value.condition);
+  const [price, setPrice] = useState<[number, number] | null>(null);
+  const [brandQuery, setBrandQuery] = useState('');
+
+  const activeCount =
+    value.brands.length +
+    value.condition.length +
+    (value.minPrice !== null || value.maxPrice !== null ? 1 : 0);
+
+  const loadData = useCallback(async () => {
+    if (loadedRef.current) return;
+    loadedRef.current = true;
+    setLoading(true);
+    try {
+      const [bRes, rRes] = await Promise.all([fetch('/api/brands'), fetch('/api/ranges')]);
+      if (bRes.ok) setAllBrands((await bRes.json()) as string[]);
+      if (rRes.ok) {
+        const d = (await rRes.json()) as { minPrice: number; maxPrice: number };
+        setBounds([d.minPrice, d.maxPrice]);
+      }
+    } catch {
+      /* keep the panel usable even if options fail to load */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Seed the price range once bounds arrive (or re-seed on open below).
+  useEffect(() => {
+    if (bounds && price === null) {
+      setPrice([value.minPrice ?? bounds[0], value.maxPrice ?? bounds[1]]);
+    }
+  }, [bounds, price, value.minPrice, value.maxPrice]);
+
+  // Desktop: centered modal via the popover's own top-layer UA centering
+  // (inset:0 + margin:auto). Mobile: a bottom sheet. No per-pixel anchoring, so
+  // it can never run off-screen.
+  const positionPanel = useCallback(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    if (window.matchMedia('(max-width: 767px)').matches) {
+      Object.assign(panel.style, {
+        top: 'auto',
+        bottom: '0',
+        left: '0',
+        right: '0',
+        width: '100%',
+        maxWidth: '100%',
+        margin: '0',
+        borderRadius: '1rem 1rem 0 0',
+      });
+    } else {
+      // Clear any mobile inline overrides so the className width/height and the
+      // UA centering take over.
+      panel.style.cssText = '';
+    }
+  }, []);
+
+  // Seed the draft + lazy-load options when the popover opens, and re-evaluate
+  // the layout (modal vs bottom sheet) on resize while open.
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const onBeforeToggle = (e: Event) => {
+      if ((e as ToggleEvent).newState !== 'open') return;
+      setBrands(value.brands);
+      setCondition(value.condition);
+      setBrandQuery('');
+      if (bounds) setPrice([value.minPrice ?? bounds[0], value.maxPrice ?? bounds[1]]);
+      loadData();
+      positionPanel();
+      window.addEventListener('resize', positionPanel);
+    };
+    const onToggle = (e: Event) => {
+      if ((e as ToggleEvent).newState === 'closed') {
+        window.removeEventListener('resize', positionPanel);
+      }
+    };
+
+    panel.addEventListener('beforetoggle', onBeforeToggle);
+    panel.addEventListener('toggle', onToggle);
+    return () => {
+      panel.removeEventListener('beforetoggle', onBeforeToggle);
+      panel.removeEventListener('toggle', onToggle);
+      window.removeEventListener('resize', positionPanel);
+    };
+  }, [value, bounds, loadData, positionPanel]);
+
+  const toggleValue = (list: string[], v: string) =>
+    list.includes(v) ? list.filter(x => x !== v) : [...list, v];
+
+  const filteredBrands = allBrands.filter(b =>
+    b.toLowerCase().includes(brandQuery.trim().toLowerCase())
+  );
+
+  const apply = () => {
+    const touchedPrice =
+      bounds && price ? price[0] !== bounds[0] || price[1] !== bounds[1] : false;
+    onApply({
+      brands,
+      condition,
+      minPrice: touchedPrice && price ? price[0] : null,
+      maxPrice: touchedPrice && price ? price[1] : null,
+    });
+    panelRef.current?.hidePopover();
+  };
+
+  const clear = () => {
+    setBrands([]);
+    setCondition([]);
+    setBrandQuery('');
+    if (bounds) setPrice([bounds[0], bounds[1]]);
+  };
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => panelRef.current?.showPopover()}
+        aria-haspopup="dialog"
+        data-track="open_home_more_filters"
+        data-track-category="home_search"
+        className="inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-primary"
+      >
+        <SlidersIcon className="h-4 w-4 text-gray-500" />
+        More filters
+        {activeCount > 0 && (
+          <span className="ml-0.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-green-600 px-1.5 text-xs font-bold text-white">
+            {activeCount}
+          </span>
+        )}
+      </button>
+
+      <div
+        ref={panelRef}
+        popover="auto"
+        aria-label="More filters"
+        className="mg-popover max-h-[85dvh] w-[28rem] max-w-[calc(100vw-2rem)] overflow-y-auto rounded-2xl bg-white p-0 shadow-2xl ring-1 ring-black/10"
+      >
+        <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+          <h2 className="text-sm font-semibold text-gray-900">More filters</h2>
+          <button
+            type="button"
+            onClick={() => panelRef.current?.hidePopover()}
+            aria-label="Close filters"
+            className="rounded-md p-1 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-primary"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="space-y-5 px-4 py-4">
+          {/* Condition */}
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-gray-900">Condition</legend>
+            <div className="flex gap-4">
+              {conditionOptions.map(opt => (
+                <label key={opt.value} className="flex items-center gap-2 text-sm text-gray-600">
+                  <input
+                    type="checkbox"
+                    value={opt.value}
+                    checked={condition.includes(opt.value)}
+                    onChange={() => setCondition(prev => toggleValue(prev, opt.value))}
+                    className="h-4 w-4 rounded border-gray-300 text-green-primary focus:ring-green-primary"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          {/* Price */}
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-gray-900">Price</legend>
+            {loading && !bounds ? (
+              <p className="text-sm text-gray-400">Loading price range…</p>
+            ) : bounds && price ? (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between text-sm text-gray-600">
+                  <span>${price[0]}</span>
+                  <span>${price[1]}</span>
+                </div>
+                <RangeSlider
+                  min={bounds[0]}
+                  max={bounds[1]}
+                  step={1}
+                  value={price}
+                  onChange={setPrice}
+                />
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">Price range unavailable.</p>
+            )}
+          </fieldset>
+
+          {/* Brands */}
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-gray-900">Brands</legend>
+            <input
+              type="search"
+              value={brandQuery}
+              onChange={e => setBrandQuery(e.target.value)}
+              placeholder="Search brands…"
+              aria-label="Search brands"
+              style={{ fontSize: '16px' }}
+              className="mb-2 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-green-primary focus:outline-none focus:ring-1 focus:ring-green-primary"
+            />
+            <div className="max-h-44 space-y-2.5 overflow-y-auto pr-1">
+              {loading && allBrands.length === 0 ? (
+                <p className="text-sm text-gray-400">Loading brands…</p>
+              ) : filteredBrands.length === 0 ? (
+                <p className="text-sm text-gray-400">No brands match “{brandQuery}”.</p>
+              ) : (
+                filteredBrands.map((brand, idx) => (
+                  <label
+                    key={brand}
+                    htmlFor={`home-brand-${idx}`}
+                    className="flex items-center gap-3 text-sm text-gray-600"
+                  >
+                    <input
+                      id={`home-brand-${idx}`}
+                      type="checkbox"
+                      value={brand}
+                      checked={brands.includes(brand)}
+                      onChange={() => setBrands(prev => toggleValue(prev, brand))}
+                      className="h-4 w-4 rounded border-gray-300 text-green-primary focus:ring-green-primary"
+                    />
+                    {brand.toUpperCase()}
+                  </label>
+                ))
+              )}
+            </div>
+          </fieldset>
+        </div>
+
+        <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-gray-100 bg-white px-4 py-3">
+          <button
+            type="button"
+            onClick={clear}
+            data-track="clear_home_filters"
+            data-track-category="home_search"
+            className="text-sm font-medium text-gray-500 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-primary"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={apply}
+            data-track="apply_home_filters"
+            data-track-category="home_search"
+            data-track-value={brands.length + condition.length}
+            className="rounded-md bg-green-600 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-green-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default HomeMoreFilters;

--- a/src/app/ui/components/ProductImageZoom/ProductImageZoom.tsx
+++ b/src/app/ui/components/ProductImageZoom/ProductImageZoom.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+
+import Image from 'next/image';
+
+import { Dialog, XMarkIcon } from '@/app/ui/components';
+
+interface ProductImageZoomProps {
+  /** Original (remote) image URL — also used un-optimized for the crisp zoom layers. */
+  src: string;
+  alt: string;
+  /** Disable zoom entirely (e.g. the generic fallback image has nothing to inspect). */
+  enabled?: boolean;
+  /** Passed through to the base next/image for correct responsive sizing. */
+  sizes?: string;
+}
+
+const LENS = 168; // lens diameter in px
+const ZOOM = 2.4; // magnification factor
+
+/**
+ * Wraps the detail page's main product image with two complementary zoom modes:
+ *
+ *  - Desktop (hover + fine pointer): a circular magnifier lens follows the
+ *    cursor. The lens shows the ORIGINAL image scaled by ZOOM with object-fit
+ *    contain, so the magnified letterboxing matches the base image exactly (no
+ *    distortion on white-background tire shots).
+ *  - Touch / click: opens a full-screen view (reusing the accessible Dialog
+ *    shell) where the photo can be panned and pinch-zoomed to inspect tread and
+ *    condition up close.
+ *
+ * The lens is purely decorative (aria-hidden); keyboard and screen-reader users
+ * open the same full-screen view via the button wrapper.
+ */
+const ProductImageZoom: FC<ProductImageZoomProps> = ({ src, alt, enabled = true, sizes }) => {
+  const containerRef = useRef<HTMLButtonElement>(null);
+  const [canHover, setCanHover] = useState(false);
+  const [lens, setLens] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(hover: hover) and (pointer: fine)');
+    const update = () => setCanHover(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const onMove = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (!enabled || !canHover) return;
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      if (x < 0 || y < 0 || x > rect.width || y > rect.height) {
+        setLens(null);
+        return;
+      }
+      setLens({ x, y, w: rect.width, h: rect.height });
+    },
+    [enabled, canHover]
+  );
+
+  const closeFullscreen = useCallback(() => setFullscreen(false), []);
+
+  const base = (
+    <Image
+      alt={alt}
+      src={src}
+      fill
+      className="object-contain object-center"
+      sizes={sizes}
+      priority={false}
+    />
+  );
+
+  // Without zoom (fallback image) keep the plain image — no interaction layer.
+  if (!enabled) {
+    return <div className="absolute inset-0">{base}</div>;
+  }
+
+  return (
+    <>
+      <button
+        ref={containerRef}
+        type="button"
+        onMouseMove={onMove}
+        onMouseLeave={() => setLens(null)}
+        onClick={() => setFullscreen(true)}
+        aria-label="Open full-size image to zoom"
+        className={`absolute inset-0 block focus:outline-none focus-visible:ring-2 focus-visible:ring-green-primary focus-visible:ring-offset-2 ${
+          canHover ? 'cursor-zoom-in' : 'cursor-pointer'
+        }`}
+      >
+        {base}
+
+        {lens && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute z-20 overflow-hidden rounded-full border border-white/70 shadow-[0_4px_20px_rgba(0,0,0,0.35)] ring-1 ring-black/10"
+            style={{
+              width: LENS,
+              height: LENS,
+              left: lens.x - LENS / 2,
+              top: lens.y - LENS / 2,
+              background: '#fff',
+            }}
+          >
+            {/* Oversized contained copy of the same image, offset so the point
+                under the cursor sits at the lens centre. Raw <img> on purpose:
+                the lens needs the original URL at an exact pixel size, not an
+                optimized/resized next/image. */}
+            <img
+              src={src}
+              alt=""
+              aria-hidden="true"
+              draggable={false}
+              style={{
+                position: 'absolute',
+                width: lens.w * ZOOM,
+                height: lens.h * ZOOM,
+                maxWidth: 'none',
+                objectFit: 'contain',
+                left: -(lens.x * ZOOM - LENS / 2),
+                top: -(lens.y * ZOOM - LENS / 2),
+              }}
+            />
+          </span>
+        )}
+      </button>
+
+      <Dialog
+        open={fullscreen}
+        onCloseAction={closeFullscreen}
+        ariaLabel={`Zoomed view: ${alt}`}
+        className="fixed inset-0 z-[120] flex items-center justify-center"
+      >
+        <div
+          className="absolute inset-0 bg-black/85 backdrop-blur-sm"
+          onClick={closeFullscreen}
+          aria-hidden="true"
+        />
+        <button
+          type="button"
+          onClick={closeFullscreen}
+          aria-label="Close zoomed view"
+          className="absolute right-4 top-4 z-10 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        >
+          <XMarkIcon className="h-6 w-6" aria-hidden />
+        </button>
+
+        {/* Pannable / pinch-zoomable surface. The image is rendered larger than
+            the viewport so it can be scrolled to inspect detail; native pinch is
+            allowed on top. */}
+        <div
+          className="relative h-[92dvh] w-full overflow-auto overscroll-contain"
+          style={{ touchAction: 'pan-x pan-y pinch-zoom' }}
+        >
+          <img
+            src={src}
+            alt={alt}
+            draggable={false}
+            className="mx-auto block h-auto w-[170%] max-w-none select-none sm:w-auto sm:max-h-[92dvh] sm:max-w-[95vw]"
+          />
+        </div>
+
+        <p className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-black/50 px-3 py-1 text-xs font-medium text-white/90">
+          Pinch or scroll to explore · tap outside to close
+        </p>
+      </Dialog>
+    </>
+  );
+};
+
+export default ProductImageZoom;

--- a/src/app/ui/components/ProductImageZoom/ProductImageZoom.tsx
+++ b/src/app/ui/components/ProductImageZoom/ProductImageZoom.tsx
@@ -4,6 +4,8 @@ import { FC, useCallback, useEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 
+import { createPortal } from 'react-dom';
+
 import { Dialog, XMarkIcon } from '@/app/ui/components';
 
 interface ProductImageZoomProps {
@@ -38,6 +40,7 @@ const ProductImageZoom: FC<ProductImageZoomProps> = ({ src, alt, enabled = true,
   const [canHover, setCanHover] = useState(false);
   const [lens, setLens] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
 
   useEffect(() => {
     const mq = window.matchMedia('(hover: hover) and (pointer: fine)');
@@ -64,7 +67,10 @@ const ProductImageZoom: FC<ProductImageZoomProps> = ({ src, alt, enabled = true,
     [enabled, canHover]
   );
 
-  const closeFullscreen = useCallback(() => setFullscreen(false), []);
+  const closeFullscreen = useCallback(() => {
+    setFullscreen(false);
+    setZoomed(false);
+  }, []);
 
   const base = (
     <Image
@@ -90,6 +96,9 @@ const ProductImageZoom: FC<ProductImageZoomProps> = ({ src, alt, enabled = true,
         onMouseMove={onMove}
         onMouseLeave={() => setLens(null)}
         onClick={() => setFullscreen(true)}
+        data-track="open_tire_image_zoom"
+        data-track-category="product_detail"
+        data-track-label={alt}
         aria-label="Open full-size image to zoom"
         className={`absolute inset-0 block focus:outline-none focus-visible:ring-2 focus-visible:ring-green-primary focus-visible:ring-offset-2 ${
           canHover ? 'cursor-zoom-in' : 'cursor-pointer'
@@ -132,45 +141,62 @@ const ProductImageZoom: FC<ProductImageZoomProps> = ({ src, alt, enabled = true,
         )}
       </button>
 
-      <Dialog
-        open={fullscreen}
-        onCloseAction={closeFullscreen}
-        ariaLabel={`Zoomed view: ${alt}`}
-        className="fixed inset-0 z-[120] flex items-center justify-center"
-      >
-        <div
-          className="absolute inset-0 bg-black/85 backdrop-blur-sm"
-          onClick={closeFullscreen}
-          aria-hidden="true"
-        />
-        <button
-          type="button"
-          onClick={closeFullscreen}
-          aria-label="Close zoomed view"
-          className="absolute right-4 top-4 z-10 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-        >
-          <XMarkIcon className="h-6 w-6" aria-hidden />
-        </button>
+      {/* Portaled to <body> so the overlay escapes the gallery's isolate/
+          overflow-hidden stacking context and reliably covers the whole
+          viewport (thumbnails included) with the close button reachable. */}
+      {fullscreen &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <Dialog
+            open
+            onCloseAction={closeFullscreen}
+            ariaLabel={`Zoomed view: ${alt}`}
+            className="fixed inset-0 z-[120] flex items-center justify-center"
+          >
+            <div
+              className="absolute inset-0 bg-black/85 backdrop-blur-sm"
+              onClick={closeFullscreen}
+              aria-hidden="true"
+            />
+            <button
+              type="button"
+              onClick={closeFullscreen}
+              aria-label="Close zoomed view"
+              className="fixed right-4 top-4 z-20 inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-600 text-white shadow-[0_2px_14px_rgba(0,0,0,0.6)] ring-2 ring-white transition-colors hover:bg-green-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              <XMarkIcon className="h-7 w-7" aria-hidden />
+            </button>
 
-        {/* Pannable / pinch-zoomable surface. The image is rendered larger than
-            the viewport so it can be scrolled to inspect detail; native pinch is
-            allowed on top. */}
-        <div
-          className="relative h-[92dvh] w-full overflow-auto overscroll-contain"
-          style={{ touchAction: 'pan-x pan-y pinch-zoom' }}
-        >
-          <img
-            src={src}
-            alt={alt}
-            draggable={false}
-            className="mx-auto block h-auto w-[170%] max-w-none select-none sm:w-auto sm:max-h-[92dvh] sm:max-w-[95vw]"
-          />
-        </div>
+            {/* Contained zoom: only the main image scales (tap to toggle), and
+                page pinch-zoom is suppressed so the close button stays
+                reachable. When zoomed the image overflows and can be panned. */}
+            <div
+              className={`relative h-[92dvh] w-full overflow-auto overscroll-contain ${
+                zoomed ? 'block' : 'flex items-center justify-center'
+              }`}
+              style={{ touchAction: zoomed ? 'pan-x pan-y' : 'none' }}
+            >
+              <img
+                src={src}
+                alt={alt}
+                draggable={false}
+                onClick={() => setZoomed(z => !z)}
+                data-track={zoomed ? 'tire_image_zoom_out' : 'tire_image_zoom_in'}
+                data-track-category="product_detail"
+                className={`block select-none ${
+                  zoomed
+                    ? 'h-auto w-[180%] max-w-none cursor-zoom-out'
+                    : 'max-h-full max-w-full cursor-zoom-in object-contain'
+                }`}
+              />
+            </div>
 
-        <p className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-black/50 px-3 py-1 text-xs font-medium text-white/90">
-          Pinch or scroll to explore · tap outside to close
-        </p>
-      </Dialog>
+            <p className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-black/50 px-3 py-1 text-xs font-medium text-white/90">
+              Tap image to zoom · tap outside to close
+            </p>
+          </Dialog>,
+          document.body
+        )}
     </>
   );
 };

--- a/src/app/ui/components/SearchBySize/SearchBySize.tsx
+++ b/src/app/ui/components/SearchBySize/SearchBySize.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useContext } from 'react';
+import { FC, useContext, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -8,6 +8,9 @@ import { SelectedFiltersContext } from '@/app/context/SelectedFilters';
 import { useTireDimensions } from '@/app/hooks/useTireDimensions';
 import { useTireSizeWithContext } from '@/app/hooks/useTireSizeWithContext';
 import { ButtonSearch } from '@/app/ui/components';
+import HomeMoreFilters, {
+  HomeExtraFilters,
+} from '@/app/ui/components/HomeMoreFilters/HomeMoreFilters';
 import TirePreview3D from '@/app/ui/components/TirePreview3D/TirePreview3D';
 import TirePreview3DMobile from '@/app/ui/components/TirePreview3D/TirePreview3DMobile';
 import { CarFront } from '@/app/ui/icons';
@@ -18,6 +21,33 @@ const URL_PARAMS = {
   sidewall: 's',
   diameter: 'd',
 };
+
+const EMPTY_FILTERS: HomeExtraFilters = {
+  brands: [],
+  condition: [],
+  minPrice: null,
+  maxPrice: null,
+};
+
+/** Removable chip for an applied non-size filter. */
+const FilterChip: FC<{ label: string; onRemove: () => void }> = ({ label, onRemove }) => (
+  <span className="inline-flex items-center gap-1 rounded-full bg-green-50 py-1 pl-3 pr-1.5 text-xs font-medium text-green-700 ring-1 ring-green-200">
+    {label}
+    <button
+      type="button"
+      onClick={onRemove}
+      data-track="remove_home_filter"
+      data-track-category="home_search"
+      data-track-label={label}
+      aria-label={`Remove ${label} filter`}
+      className="flex h-4 w-4 items-center justify-center rounded-full text-green-600 hover:bg-green-200 hover:text-green-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+    >
+      <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+      </svg>
+    </button>
+  </span>
+);
 
 const SearchBySize: FC = () => {
   const { selectedFilters } = useContext(SelectedFiltersContext);
@@ -38,7 +68,10 @@ const SearchBySize: FC = () => {
 
   const router = useRouter();
 
-  const handleSearch = () => {
+  // Extra (non-size) filters chosen via the "More filters" panel.
+  const [extraFilters, setExtraFilters] = useState<HomeExtraFilters>(EMPTY_FILTERS);
+
+  const buildUrl = (extra: HomeExtraFilters) => {
     const params = new URLSearchParams();
 
     Object.entries(selectedFilters).forEach(([key, value]) => {
@@ -48,8 +81,31 @@ const SearchBySize: FC = () => {
       }
     });
 
-    router.push(`/tires?${params.toString()}`);
+    // Param names match what /tires (buildTireFilters) already understands.
+    if (extra.brands.length) params.append('brands', extra.brands.join(','));
+    if (extra.condition.length) params.append('condition', extra.condition.join(','));
+    if (extra.minPrice !== null) params.append('minPrice', String(extra.minPrice));
+    if (extra.maxPrice !== null) params.append('maxPrice', String(extra.maxPrice));
+
+    return `/tires?${params.toString()}`;
   };
+
+  const handleSearch = () => router.push(buildUrl(extraFilters));
+
+  // Apply only stages the filters as chips; the main Search button runs the
+  // actual search (size + any staged filters).
+  const handleApplyFilters = (extra: HomeExtraFilters) => setExtraFilters(extra);
+
+  const removeBrand = (brand: string) =>
+    setExtraFilters(prev => ({ ...prev, brands: prev.brands.filter(b => b !== brand) }));
+  const removeCondition = (value: string) =>
+    setExtraFilters(prev => ({ ...prev, condition: prev.condition.filter(c => c !== value) }));
+  const removePrice = () =>
+    setExtraFilters(prev => ({ ...prev, minPrice: null, maxPrice: null }));
+
+  const hasPriceFilter = extraFilters.minPrice !== null || extraFilters.maxPrice !== null;
+  const hasExtraFilters =
+    extraFilters.brands.length > 0 || extraFilters.condition.length > 0 || hasPriceFilter;
 
   // Manejador integrado para el cambio de dimensiones
   const handleDimensionChange = (value: string, type: 'width' | 'sidewall' | 'diameter') => {
@@ -71,6 +127,9 @@ const SearchBySize: FC = () => {
   };
 
   const canSearch = isComplete();
+  // Allow searching with only filters (no complete size), so brand/price-only
+  // searches aren't blocked by the "select all measurements" gate.
+  const searchEnabled = canSearch || hasExtraFilters;
 
   return (
     <>
@@ -84,7 +143,7 @@ const SearchBySize: FC = () => {
               </div>
               <TirePreview3DMobile
                 onSearch={handleSearch}
-                canSearch={canSearch}
+                canSearch={searchEnabled}
                 selector={{
                   currentSize: tireSize,
                   width: widthOptions,
@@ -109,7 +168,28 @@ const SearchBySize: FC = () => {
               isLoadingSidewall={isLoadingSidewall}
               isLoadingDiameter={isLoadingDiameter}
             />
-            <ButtonSearch onClick={handleSearch} disabled={canSearch} />
+
+            <div className="flex flex-wrap items-center gap-2">
+              <HomeMoreFilters value={extraFilters} onApply={handleApplyFilters} />
+              {extraFilters.brands.map(brand => (
+                <FilterChip key={`b-${brand}`} label={brand} onRemove={() => removeBrand(brand)} />
+              ))}
+              {extraFilters.condition.map(value => (
+                <FilterChip
+                  key={`c-${value}`}
+                  label={value === 'new' ? 'New' : 'Used'}
+                  onRemove={() => removeCondition(value)}
+                />
+              ))}
+              {hasPriceFilter && (
+                <FilterChip
+                  label={`$${extraFilters.minPrice ?? 0}–$${extraFilters.maxPrice ?? '∞'}`}
+                  onRemove={removePrice}
+                />
+              )}
+            </div>
+
+            <ButtonSearch onClick={handleSearch} disabled={searchEnabled} />
           </div>
         </div>
         <div className="hidden md:flex items-stretch justify-center flex-1">

--- a/src/app/ui/components/TirePreview3D/TirePreview3D.tsx
+++ b/src/app/ui/components/TirePreview3D/TirePreview3D.tsx
@@ -7,8 +7,24 @@ import dynamic from 'next/dynamic';
 import { SelectedFiltersContext } from '@/app/context/SelectedFilters';
 import { ArrowsToRight } from '@/app/ui/icons';
 
+import { TIRE_3D_HINT_KEY, useDiscoveryHint } from './useDiscoveryHint';
 import { isWebglAvailable } from './webgl';
 import TireDisplay from '../TireDisplay/TireDisplay';
+
+/** Small circular-arrow glyph for the "Drag to rotate" cue (inline so it scales
+ *  with the chip and inherits currentColor — the shared RotationIcon is fixed-
+ *  size and un-styleable). */
+const RotateGlyph = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M4 12a8 8 0 0 1 13.66-5.66M20 12a8 8 0 0 1-13.66 5.66"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <path d="M17 3v3.5h-3.5M7 21v-3.5h3.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
 
 const Skeleton = () => (
   <div className="w-full h-full flex items-center justify-center">
@@ -32,6 +48,16 @@ const TirePreview3D: FC = () => {
   // null = still detecting; true/false = decision made (avoids SSR/hydration flash).
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [reducedMotion, setReducedMotion] = useState(false);
+  const hint = useDiscoveryHint(TIRE_3D_HINT_KEY);
+  // Visually retire the "Drag to rotate" chip after a few seconds even without
+  // interaction; persistence still only happens once the user actually drags.
+  const [hintFaded, setHintFaded] = useState(false);
+
+  useEffect(() => {
+    if (!hint.show) return;
+    const t = setTimeout(() => setHintFaded(true), 6000);
+    return () => clearTimeout(t);
+  }, [hint.show]);
 
   useEffect(() => {
     const desktop = window.matchMedia('(min-width: 768px)');
@@ -64,10 +90,23 @@ const TirePreview3D: FC = () => {
   return (
     <div className="relative w-full h-full">
       {/* Decorative canvas (transparent — the white card shows through). The
-          dropdowns + the badge below carry the meaning. */}
-      <div className="absolute inset-0" aria-hidden="true">
+          dropdowns + the badge below carry the meaning. A first drag dismisses
+          the discovery hint for good. */}
+      <div className="absolute inset-0" aria-hidden="true" onPointerDown={hint.dismiss}>
         <TireScene size={size} reducedMotion={reducedMotion} />
       </div>
+
+      {/* One-time "this is interactive" cue so users notice the 3D selector and
+          that they can spin it. Subtle, capped pulse; gone after the first drag
+          or a few seconds, and never shown again once discovered. */}
+      {hint.show && !hintFaded && (
+        <div className="pointer-events-none absolute left-1/2 top-2 z-10 -translate-x-1/2">
+          <span className="mg-attention inline-flex items-center gap-1.5 rounded-full bg-neutral-900/85 px-3 py-1 text-xs font-medium text-white shadow-lg ring-1 ring-white/10">
+            <RotateGlyph className="h-3.5 w-3.5 text-green-400" />
+            Drag to rotate
+          </span>
+        </div>
+      )}
 
       {/* Disclaimer — this is a size-orientation aid, not an exact tire model. */}
       <span

--- a/src/app/ui/components/TirePreview3D/TirePreview3DMobile.tsx
+++ b/src/app/ui/components/TirePreview3D/TirePreview3DMobile.tsx
@@ -12,6 +12,7 @@ import { ButtonSearch, XMarkIcon } from '@/app/ui/components';
 import { ArrowsToRight, CarFront } from '@/app/ui/icons';
 import { SizeSelectors } from '@/app/ui/sections';
 
+import { TIRE_3D_HINT_KEY, useDiscoveryHint } from './useDiscoveryHint';
 import { isWebglAvailable } from './webgl';
 
 const TireScene = dynamic(() => import('./TireScene'), {
@@ -37,6 +38,7 @@ const TirePreview3DMobile: FC<{
   const [supported, setSupported] = useState(false);
   const [open, setOpen] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);
+  const hint = useDiscoveryHint(TIRE_3D_HINT_KEY);
 
   useEffect(() => {
     setSupported(isWebglAvailable());
@@ -77,13 +79,18 @@ const TirePreview3DMobile: FC<{
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          hint.dismiss();
+          setOpen(true);
+        }}
         data-track="open_tire_3d"
         data-track-category="home_search"
-        className="md:hidden inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold text-green-700 transition-colors hover:bg-green-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+        className={`md:hidden inline-flex items-center gap-1.5 rounded-full border border-green-200 bg-green-50 px-2.5 py-1 text-xs font-semibold text-green-700 transition-colors hover:bg-green-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 ${
+          hint.show ? 'mg-attention' : ''
+        }`}
       >
         <CarFront className="h-3.5 w-3.5" />
-        3D
+        View in 3D
       </button>
 
       {open &&

--- a/src/app/ui/components/TirePreview3D/useDiscoveryHint.ts
+++ b/src/app/ui/components/TirePreview3D/useDiscoveryHint.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/** Shared key for the 3D-selector onboarding nudge: discovering the feature in
+ *  either the mobile button or the desktop canvas stops the cue everywhere. */
+export const TIRE_3D_HINT_KEY = 'mg_3d_discovered';
+
+/**
+ * One-time onboarding nudge. Returns whether a subtle attention cue should be
+ * shown (only until the user has discovered the feature once) plus a `dismiss`
+ * callback that marks it seen so it never nags on later visits.
+ *
+ * SSR-safe: starts hidden and decides after mount, so the cue can't flash
+ * during hydration. localStorage failures (private mode, blocked storage) are
+ * swallowed — the worst case is simply showing/omitting the hint.
+ */
+export function useDiscoveryHint(key: string) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(key)) setShow(true);
+    } catch {
+      /* storage unavailable — skip the nudge */
+    }
+  }, [key]);
+
+  const dismiss = () => {
+    setShow(false);
+    try {
+      localStorage.setItem(key, '1');
+    } catch {
+      /* no-op */
+    }
+  };
+
+  return { show, dismiss };
+}

--- a/src/app/ui/sections/ProductCarousel/ProductCarousel.tsx
+++ b/src/app/ui/sections/ProductCarousel/ProductCarousel.tsx
@@ -2,10 +2,11 @@
 
 import React, { FC, useCallback, useMemo, useState } from 'react';
 
-import Image from 'next/image';
-
 import { TireInformationProps } from '@/app/interfaces/tires';
 import { ProductCondition, ProductCarouselMiniature, StockBadge } from '@/app/ui/components';
+import ProductImageZoom from '@/app/ui/components/ProductImageZoom/ProductImageZoom';
+
+const FALLBACK_IMAGE = '/assets/images/generic-tire-image.webp';
 
 const ProductCarousel: FC<TireInformationProps> = ({ singleTire }) => {
   const images = useMemo(() => singleTire.images || [], [singleTire.images]);
@@ -36,9 +37,12 @@ const ProductCarousel: FC<TireInformationProps> = ({ singleTire }) => {
   const current = images[index] || {
     id: 0,
     name: 'Image',
-    src: '/assets/images/generic-tire-image.webp',
+    src: FALLBACK_IMAGE,
     alt: `${singleTire.brand} ${singleTire.name}`,
   };
+
+  // Nothing to inspect on the generic placeholder — disable zoom for it.
+  const zoomEnabled = current.src !== FALLBACK_IMAGE;
 
   return (
     <div className="flex flex-col-reverse" aria-label="Product gallery">
@@ -95,13 +99,11 @@ const ProductCarousel: FC<TireInformationProps> = ({ singleTire }) => {
           className="w-full"
         >
           <div className="relative isolate w-full bg-white rounded-lg overflow-hidden aspect-square sm:aspect-[16/10] lg:aspect-[16/9]">
-            <Image
-              alt={current.alt || current.name}
+            <ProductImageZoom
               src={current.src}
-              fill
-              className="object-contain object-center"
+              alt={current.alt || current.name}
+              enabled={zoomEnabled}
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 600px"
-              priority={false}
             />
             <div className="pointer-events-none absolute top-2 left-2 z-30">
               <ProductCondition condition={singleTire.condition} />


### PR DESCRIPTION
This pull request introduces several user experience improvements and new features to the home search and product detail UI, focusing on enhanced filtering and product image interaction. The main changes include adding a "More filters" modal for the home search, supporting multiple filter parameters in the URL, and implementing an interactive product image zoom with both lens and fullscreen modes. Additionally, new CSS is added to support these UI features.

**New Home Search Filters and Product Image Zoom**

### Home Search Filters

* Added a new `HomeMoreFilters` modal component, allowing users to filter by brand, condition, and price on the home page. The modal uses the native Popover API, adapts to mobile and desktop layouts, and lazy-loads filter options (`HomeMoreFilters.tsx`).
* Introduced a `FilterChip` component and supporting logic in `SearchBySize` to display and remove applied non-size filters. Also added the `EMPTY_FILTERS` constant for initializing filter state (`SearchBySize.tsx`).
* Updated the brand scroller logic to highlight the active brand from either the `?brand=` or a single-value `?brands=` URL parameter, ensuring consistent UI when arriving from different filter sources (`BrowseFilters.tsx`).

### Product Detail Image Zoom

* Added a new `ProductImageZoom` component that provides:
  - Desktop: a circular magnifier lens on image hover.
  - Touch/click: a fullscreen dialog with pinch-to-zoom and pan support.
  - Accessibility and tracking enhancements for analytics (`ProductImageZoom.tsx`).

### Styling and UI Enhancements

* Added CSS for:
  - An attention halo animation for onboarding cues (e.g., the 3D selector).
  - Centered modal and blurred backdrop for the "More filters" popover.
  - Ensured popover compatibility with Tailwind resets (`globals.css`). [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R12-R29) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R65-R81)

These changes collectively improve the discoverability and usability of filters on the home page and provide a richer, more interactive product detail experience.